### PR TITLE
Update runner node choice

### DIFF
--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -72,6 +72,10 @@ jobs:
           echo "/home/locoadmin/bin" >> $GITHUB_PATH
           echo "/usr/local/cuda/bin" >> $GITHUB_PATH
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 16
+
       - uses: actions/checkout@main
         with:
           fetch-depth: 0

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -76,7 +76,7 @@ jobs:
         with:
           node-version: 16
 
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v3.6.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -72,7 +72,7 @@ jobs:
           echo "/home/locoadmin/bin" >> $GITHUB_PATH
           echo "/usr/local/cuda/bin" >> $GITHUB_PATH
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v3.8.2
         with:
           node-version: 16
 


### PR DESCRIPTION
Force the gh action runner to use a specific node version via the setup-node action.