### PR TITLE
updates to incorporate the matrix chunking method

### DIFF
--- a/src/matvis/core/matprod.py
+++ b/src/matvis/core/matprod.py
@@ -20,6 +20,9 @@ class MatProd(ABC):
         Number of antennas.
     antpairs
         The antenna pairs to sum over. If None, all pairs are used.
+	matsets
+		The list of sub-matrices to calculate.  If None, all pairs are used in a single
+		matrix multiplication.  
     precision
         The precision of the data (1 or 2).
     """
@@ -29,15 +32,18 @@ class MatProd(ABC):
         nchunks: int,
         nfeed: int,
         nant: int,
-        antpairs: np.ndarray | None,
+        antpairs: np.ndarray | list | None,
+		matsets: list | None,
         precision=1,
     ):
         if antpairs is None:
             self.all_pairs = True
             self.antpairs = np.array([(i, j) for i in range(nant) for j in range(nant)])
+            self.matsets = list([(np.array([i]), np.array([j])) for i in range(nant) for j in range(nant)])
         else:
             self.all_pairs = False
             self.antpairs = antpairs
+            self.matsets  = matsets
 
         self.nchunks = nchunks
         self.nfeed = nfeed

--- a/src/matvis/cpu/cpu.py
+++ b/src/matvis/cpu/cpu.py
@@ -32,6 +32,7 @@ def simulate(
     I_sky: np.ndarray,
     beam_list: Sequence[UVBeam | Callable] | None,
     antpairs: np.ndarray | list[tuple[int, int]] | None = None,
+	matsets: list[tuple[np.ndarray[int], np.ndarray[int]]] | None = None,
     precision: int = 1,
     polarized: bool = False,
     beam_idx: np.ndarray | None = None,
@@ -81,6 +82,13 @@ def simulate(
         Either a 2D array, shape ``(Npairs, 2)``, or list of 2-tuples of ints, with
         the list of antenna-pairs to return as visibilities (all feed-pairs are always
         calculated). If None, all feed-pairs are returned.
+	matsets  :: array_like, optional
+		 A list of containing a set of 2-tuples of numpy arrays.  Each entry in the list 
+		 corresponds to a different sub-matrix.  The first element of the ith tuple lists the rows of Z corresponding
+		 to the rows of the ith sub-matrix, and the second tuple element contains the list of columns.  In the case
+		 of vector-vector loop, the number of tuples is equal to Npairs and each element of the tuple contains only
+		 one int, such that the sub-matrices contain only one element each.  Outer dimension has to be a list because
+		 numpy doesn't like inhomogeneous arrays.  
     precision : int, optional
         Which precision level to use for floats and complex numbers.
         Allowed values:
@@ -99,16 +107,27 @@ def simulate(
     max_progress_reports : int, optional
         Maximum number of progress reports to print to the screen (if logging level
         allows). Default is 100.
-    matprod_method : str, optional
-        The method to use for the final matrix multiplication. Default is 'CPUMatMul',
-        which simply uses `np.dot` over the two full matrices. Currently, the other
-        option is `CPUVectorLoop`, which uses a loop over the antenna pairs,
-        computing the sum over sources as a vector dot product.
-        Whether to calculate visibilities for each antpair in antpairs as a vector
-        dot-product instead of using a full matrix-matrix multiplication for all
-        possible pairs. Default is False. Setting to True can be faster for large
-        arrays where `antpairs` is small (possibly from high redundancy). You should
-        run a performance test before using this.
+    #matprod_method : str, optional
+    #    The method to use for the final matrix multiplication. Default is 'CPUMatMul',
+    #    which simply uses `np.dot` over the two full matrices. Currently, the other
+    #    option is `CPUVectorLoop`, which uses a loop over the antenna pairs,
+    #    computing the sum over sources as a vector dot product.
+    #    Whether to calculate visibilities for each antpair in antpairs as a vector
+    #    dot-product instead of using a full matrix-matrix multiplication for all
+    #    possible pairs. Default is False. Setting to True can be faster for large
+    #    arrays where `antpairs` is small (possibly from high redundancy). You should
+    #    run a performance test before using this.
+	matprod_method : str, optional
+		The method to use for the final matrix multiplication. Default is 'CPUMatMul',
+        which simply uses `np.dot` over the two full matrices. The second option is 
+		`CPUVectorLoop`, which uses a loop over the antenna pairs, computing the sum 
+		over sources as a vector dot product.  The third option is ``CPUMatChunk'', which
+		divides the product into several matrix multiplications that are optimized to have the 
+		highest possible density of non-redundant pairs without invoking the overhead of a large
+		for loop over vector products.  For very large arrays, with very high redundancy, CPUVectorLoop
+		is usually fastest, while for cases with low redundancy, 'CPUMatMul' is fastest.  The ``CPUMatChunk''
+		can sometimes be fastest for intermediate levels of redundancy and intermediately sized arrays.  You should
+		run a performance test before choosing one of these options.  
     max_memory : int, optional
         The maximum memory (in bytes) to use for the visibility calculation. This is
         not a hard-set limit, but rather a guideline for how much memory to use. If the
@@ -175,7 +194,7 @@ def simulate(
         source_buffer=source_buffer,
     )
     mpcls = getattr(mp, matprod_method)
-    matprod = mpcls(nchunks, nfeed, nant, antpairs, precision=precision)
+    matprod = mpcls(nchunks, nfeed, nant, antpairs, matsets, precision=precision)
     zcalc = ZMatrixCalc(
         nsrc=nsrc_alloc,
         nfeed=nfeed,

--- a/src/matvis/gpu/gpu.py
+++ b/src/matvis/gpu/gpu.py
@@ -49,6 +49,7 @@ def simulate(
     beam_list: Sequence[UVBeam | Callable] | None,
     polarized: bool = False,
     antpairs: np.ndarray | list[tuple[int, int]] | None = None,
+	matsets: list[tuple[np.ndarray[int], np.ndarray[int]]] | None = None,
     beam_idx: np.ndarray | None = None,
     max_memory: int = np.inf,
     min_chunks: int = 1,
@@ -120,7 +121,7 @@ def simulate(
         ctype=ctype,
     )
     mpcls = getattr(mp, matprod_method)
-    matprod = mpcls(nchunks, nfeed, nant, antpairs, precision=precision)
+    matprod = mpcls(nchunks, nfeed, nant, antpairs, matsets, precision=precision)
 
     npixc = nsrc // nchunks
 

--- a/src/matvis/gpu/matprod.py
+++ b/src/matvis/gpu/matprod.py
@@ -92,3 +92,45 @@ class GPUVectorDot(MatProd):
 
         out[:] = self.vis[0].transpose((2, 0, 1)).get()
         cp.cuda.Device().synchronize()
+
+
+class GPUMatChunk(MatProd):
+    """Use a loop over specific pairs, performing a vdot over the source axis."""
+
+    def allocate_vis(self):
+        """Allocate memory for the visibilities."""
+        self.vis = [
+            cp.full(
+                (self.nfeed, self.nfeed, self.npairs), 0.0, dtype=self.ctype, order="F"
+            )
+            for _ in range(self.nchunks)
+        ]
+		
+    def compute(self, z: cp.ndarray, out: cp.ndarray) -> cp.ndarray:
+        """Perform the source-summing operation for a single time and chunk."""
+        z = z.reshape((self.nant, self.nfeed, -1))
+		
+        mat_product = cp.zeros((self.nant,self.nant,self.nfeed,self.nfeed),dtype=z.dtype)
+
+        for j in range(self.nfeed): 
+            for k in range(self.nfeed): 
+                for i, (ai, aj) in enumerate(self.matsets):
+                    AI,AJ = cp.meshgrid(ai,aj)
+                    mat_product[AI,AJ,j,k] = z[ai[:],j].conj().dot(z[aj[:],k].T).T
+					
+        for j in range(self.nfeed): 
+            for k in range(self.nfeed): 
+                for i, (ai, aj) in enumerate(self.antpairs): 
+                    out[j,k,i] = mat_product[ai,aj,j,k]
+
+        cp.cuda.Device().synchronize()
+        return out
+		
+    def sum_chunks(self, out: np.ndarray):
+        """Sum the chunks into the output array."""
+        if self.nchunks > 1:
+            for i in range(1, len(self.vis)):
+                self.vis[0] += self.vis[i]
+
+        out[:] = self.vis[0].transpose((2, 0, 1)).get()
+        cp.cuda.Device().synchronize()

--- a/src/matvis/wrapper.py
+++ b/src/matvis/wrapper.py
@@ -28,6 +28,7 @@ def simulate_vis(
     beam_spline_opts: dict | None = None,
     beam_idx: np.ndarray | None = None,
     antpairs: np.ndarray | list[tuple[int, int]] | None = None,
+	matsets: list[tuple[np.ndarray[int], np.ndarray[int]]] | None = None, # set of sub-matrices
     source_buffer: float = 1.0,
     **backend_kwargs,
 ):
@@ -129,6 +130,7 @@ def simulate_vis(
     ]
 
     npairs = len(antpairs) if antpairs is not None else nants * nants
+    #npairs = sum(np.array([len(antpairs[i][0])*len(antpairs[i][1]) for i in range(len(antpairs))])) if antpairs is not None else nants * nants
     if polarized:
         vis = np.zeros(
             (freqs.size, lsts.size, npairs, nfeeds, nfeeds), dtype=complex_dtype
@@ -150,6 +152,7 @@ def simulate_vis(
             beam_spline_opts=beam_spline_opts,
             beam_idx=beam_idx,
             antpairs=antpairs,
+			matsets=matsets,
             source_buffer=source_buffer,
             **backend_kwargs,
         )

--- a/tests/matmul_checks/check_matsets_ordering.py
+++ b/tests/matmul_checks/check_matsets_ordering.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+# this test ensures that we are indexing the matrix product correctly to get the unique ant pairs when using the sub-matrix method
+
+Nant = 10
+
+V = np.zeros((Nant,Nant))
+
+for i in range(Nant): 
+	for j in range(Nant): 
+		V[i,j] = Nant*i + j
+		
+print(V)
+
+pairs = np.array([[0,3],[1,2],[2,3],[1,5],[6,7],[5,8],[6,9],[7,9],[8,9]])
+antpairs = np.copy(pairs)
+
+for i in range(len(pairs)): 
+	pairs[i] = np.array(pairs[i])
+	
+print(V[pairs[:,0],pairs[:,1]]) # print out the unique elements of V
+
+matsets = [(np.array([0,1,2]),np.array([2,3,5])),(np.array([5,6,7,8]),np.array([7,8,9]))]
+
+mat_product = np.zeros((Nant,Nant))
+out = np.zeros(len(antpairs))
+
+for i, (ai,aj) in enumerate(matsets): 
+	AI,AJ = np.meshgrid(ai,aj)
+	mat_product[AI,AJ] = V[AI,AJ]
+	
+for i, (ai,aj) in enumerate(antpairs):
+	 out[i] = mat_product[ai,aj]
+
+print(mat_product) 
+print(out) # should be the same as the second print statement
+
+

--- a/tests/test_matprod.py
+++ b/tests/test_matprod.py
@@ -1,8 +1,12 @@
 """Tests that the various matprod methods produce the same result."""
 
+import sys
+sys.path.insert(0,'/home/lab-admin/Desktop/Desktop/Graduate_School/Research/ASU/21_group/matvis/src/')
+
 import pytest
 
 import numpy as np
+import cupy as cp
 
 from matvis._utils import get_dtypes
 
@@ -16,9 +20,9 @@ def simple_matprod(z):
 @pytest.mark.parametrize("antpairs", [True, False])
 @pytest.mark.parametrize("precision", [1, 2])
 @pytest.mark.parametrize(
-    "method", ["CPUMatMul", "CPUVectorDot", "GPUMatMul", "GPUVectorDot"]
+    "method", ["CPUMatMul", "CPUVectorDot", "CPUMatChunk"]#, "GPUMatMul", "GPUVectorDot"]
 )
-def test_matprod(nfeed, antpairs, precision, method):
+def test_matprod(nfeed, antpairs, matsets, precision, method):
     """Test that the various matprod methods produce the same result."""
     if method.startswith("GPU"):
         pytest.importorskip("cupy")
@@ -35,8 +39,15 @@ def test_matprod(nfeed, antpairs, precision, method):
         antpairs = np.array([(i, j) for i in range(nant) for j in range(nant)])
     else:
         antpairs = None
-
-    obj = cls(nchunks=1, nfeed=nfeed, nant=nant, antpairs=antpairs, precision=precision)
+        
+    if matsets and method.startswith("CPU"): 
+        matsets = [(np.array([0,1,2,3]),np.array([0,1,2,3])),(np.array([0,1,2,3]),np.array([3,4])),(np.array([3,4]),np.array([0,1,2,3])),(np.array([3,4]),np.array([3,4]))] 
+    elif matsets and method.startswith("GPU"): 
+        matsets = [(cp.array([0,1,2,3]),cp.array([0,1,2,3])),(cp.array([0,1,2,3]),cp.array([3,4])),(cp.array([3,4]),cp.array([0,1,2,3])),(cp.array([3,4]),cp.array([3,4]))] 
+    else: 
+        matsets = None
+	
+    obj = cls(nchunks=1, nfeed=nfeed, nant=nant, antpairs=antpairs, matsets=matsets, precision=precision)
     obj.setup()
 
     ctype = get_dtypes(precision)[1]
@@ -60,7 +71,18 @@ def test_matprod(nfeed, antpairs, precision, method):
     )
     if method.startswith("GPU"):
         true = true.get()
+        
+    print(np.shape(out))
+    print(np.shape(true))
+    print(out)
+    print(true)
+    print(out-true)
 
     assert out.dtype.type == ctype
     assert out.shape == (obj.npairs, nfeed, nfeed)
     np.testing.assert_allclose(out, true)
+
+#antpairs = np.array([(1,2),(1,3),(3,2),(3,4),(4,4)])
+
+#test_matprod(2,True,True,1,"CPUMatChunk")
+test_matprod(2,True,True,1,"GPUMatChunk")


### PR DESCRIPTION
This update adds the capability to use the matrix chunking method to do matrix multiplication, alongside the full matrix product and vector-vector method.  This mode takes a new argument "matsets", which is a list of tuples of arrays of rows and columns, which specify sub-matrices.  After the sub-matrices are multiplied, the unique pairs are selected from the results (as specified by antpairs) and the output is only the unique pairs, just like in the vector-vector case.  I've tested that the new matrix multiplication method itself works properly with the new inputs, but I haven't checked that the updates to the API are correct yet.  