### PR TITLE
perf: ability to pre-fix the BCRS coordinates

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     line-profiler
     numpy>=2.0
     psutil
-    pyuvdata@git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata
+    pyuvdata>=3.1.0
     rich
     scipy
 python_requires = >=3.9

--- a/src/matvis/cli.py
+++ b/src/matvis/cli.py
@@ -382,7 +382,16 @@ def get_stats_and_lines(filename, start_lineno, timings, time_unit):
 
 
 def get_standard_sim_params(
-    use_analytic_beam: bool, nfreq, ntime, nants, nsource, nbeams, naz=360, nza=180
+    use_analytic_beam: bool,
+    nfreq,
+    ntime,
+    nants,
+    nsource,
+    nbeams,
+    naz=360,
+    nza=180,
+    freq_min=100e6,
+    freq_max=200e6,
 ):
     """Create some standard random simulation parameters for use in profiling.
 
@@ -446,7 +455,7 @@ def get_standard_sim_params(
     spec_indx = np.random.normal(0.8, scale=0.05, size=nsource)
 
     # Source locations and frequencies
-    freqs = np.linspace(100e6, 200e6, nfreq)
+    freqs = np.linspace(freq_min, freq_max, nfreq)
 
     # Calculate source fluxes for matvis
     flux = ((freqs[:, np.newaxis] / freqs[0]) ** spec_indx.T * flux0.T).T

--- a/src/matvis/core/coords.py
+++ b/src/matvis/core/coords.py
@@ -67,7 +67,10 @@ class CoordinateRotation(ABC):
 
         self.chunk_size = chunk_size or self.nsrc
         self.source_buffer = source_buffer
-        self.nsrc_alloc = int(self.chunk_size * self.source_buffer)
+        if self.chunk_size > 1000:
+            self.nsrc_alloc = int(self.chunk_size * self.source_buffer)
+        else:
+            self.nsrc_alloc = self.chunk_size
 
     def setup(self):
         """Allocate memory for the rotation."""

--- a/src/matvis/cpu/coords.py
+++ b/src/matvis/cpu/coords.py
@@ -82,7 +82,9 @@ class CoordinateRotationERFA(CoordinateRotation):
         # BCRS holds the deflected, aberrated bnp-d coordinates, which don't change
         # significantly over time.
         if not hasattr(self, "_bcrs"):
-            self._bcrs = self.xp.full(self._eci.shape, dtype=self._eci.dtype)
+            self._bcrs = self.xp.full(
+                self._eci.shape, dtype=self._eci.dtype, fill_value=0.0
+            )
 
     def _atioq(self, xyz: np.ndarray, astrom):
         # cirs to hadec rot

--- a/src/matvis/cpu/cpu.py
+++ b/src/matvis/cpu/cpu.py
@@ -157,20 +157,8 @@ def simulate(
         precision,
         source_buffer=source_buffer,
     )
-    nsrc_alloc = int(npixc * source_buffer)
-
-    bmfunc = UVBeamInterpolator(
-        beam_list=beam_list,
-        beam_idx=beam_idx,
-        polarized=polarized,
-        nant=nant,
-        freq=freq,
-        spline_opts=beam_spline_opts,
-        precision=precision,
-        nsrc=nsrc_alloc,
-    )
-
     coord_method = CoordinateRotation._methods[coord_method]
+
     coord_method_params = coord_method_params or {}
     coords = coord_method(
         flux=np.sqrt(0.5 * I_sky),
@@ -182,6 +170,19 @@ def simulate(
         source_buffer=source_buffer,
         **coord_method_params,
     )
+
+    nsrc_alloc = coords.nsrc_alloc
+    bmfunc = UVBeamInterpolator(
+        beam_list=beam_list,
+        beam_idx=beam_idx,
+        polarized=polarized,
+        nant=nant,
+        freq=freq,
+        spline_opts=beam_spline_opts,
+        precision=precision,
+        nsrc=nsrc_alloc,
+    )
+
     taucalc = TauCalculator(
         antpos=antpos, freq=freq, precision=precision, nsrc=nsrc_alloc
     )


### PR DESCRIPTION
This adds the option to pre-set the `_bcrs` coordinates in the ERFA coord manager. This is useful if using the option `update_bcrs_every=np.inf`, so that the BCRS matrix is set _outside_ the `setup()` (which is called inside multiprocessing tasks).