### PR TITLE
maint: update API to conform to new pyuvdata conventions.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,10 +25,10 @@ install_requires =
     line-profiler
     numpy>=2.0
     psutil
-    pyuvdata>=3.1.0
+    pyuvdata>=3.1.1
     rich
     scipy
-python_requires = >=3.9
+python_requires = >=3.10
 include_package_data = True
 package_dir =
     =src

--- a/src/matvis/cpu/beams.py
+++ b/src/matvis/cpu/beams.py
@@ -24,24 +24,19 @@ class UVBeamInterpolator(BeamInterpolator):
         # Primary beam pattern using direct interpolation of UVBeam object
         az, za = enu_to_az_za(enu_e=tx, enu_n=ty, orientation="uvbeam")
 
+        kw = {
+            "reuse_spline": True,
+            "check_azza_domain": False,
+            "interpolation_function": "az_za_map_coordinates",
+            "spline_opts": self.spline_opts,
+        }
         for i, bm in enumerate(self.beam_list):
-            kw = (
-                {
-                    "reuse_spline": True,
-                    "check_azza_domain": False,
-                    "interpolation_function": "az_za_map_coordinates",
-                    "spline_opts": self.spline_opts,
-                }
-                if isinstance(bm, UVBeam)
-                else {}
-            )
-
-            interp_beam = bm.interp(
+            interp_beam = bm.compute_response(
                 az_array=az,
                 za_array=za,
                 freq_array=np.array([self.freq]),
                 **kw,
-            )[0]
+            )
 
             if self.polarized:
                 interp_beam = interp_beam[:, :, 0, :].transpose((1, 0, 2))

--- a/src/matvis/cpu/cpu.py
+++ b/src/matvis/cpu/cpu.py
@@ -11,6 +11,8 @@ from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from collections.abc import Sequence
 from pyuvdata import UVBeam
+from pyuvdata.analytic_beam import AnalyticBeam
+from pyuvdata.beam_interface import BeamInterface
 from typing import Callable, Literal
 
 from .._utils import get_desired_chunks, get_dtypes, log_progress, logdebug, memtrace
@@ -32,7 +34,7 @@ def simulate(
     skycoords: SkyCoord,
     telescope_loc: EarthLocation,
     I_sky: np.ndarray,
-    beam_list: Sequence[UVBeam | Callable] | None,
+    beam_list: Sequence[UVBeam | AnalyticBeam | BeamInterface] | None,
     antpairs: np.ndarray | list[tuple[int, int]] | None = None,
     precision: int = 1,
     polarized: bool = False,

--- a/src/matvis/gpu/beams.py
+++ b/src/matvis/gpu/beams.py
@@ -30,8 +30,8 @@ class GPUBeamInterpolator(BeamInterpolator):
         Decides if the beam_list is a list of UVBeam objects or AnalyticBeam objects,
         and dispatches accordingly.
         """
-        self.use_interp = isinstance(self.beam_list[0], UVBeam)
-        if self.use_interp and not all(isinstance(b, UVBeam) for b in self.beam_list):
+        self.use_interp = self.beam_list[0]._isuvbeam
+        if self.use_interp and not all(b._isuvbeam for b in self.beam_list):
             raise ValueError(
                 "GPUBeamInterpolator only supports beam_lists with either all UVBeam or all AnalyticBeam objects."
             )

--- a/src/matvis/gpu/gpu.py
+++ b/src/matvis/gpu/gpu.py
@@ -13,6 +13,8 @@ from astropy.time import Time
 from collections.abc import Sequence
 from docstring_parser import combine_docstrings
 from pyuvdata import UVBeam
+from pyuvdata.analytic_beam import AnalyticBeam
+from pyuvdata.beam_interface import BeamInterface
 from typing import Callable, Literal
 
 from .._utils import get_desired_chunks, get_dtypes, log_progress, logdebug
@@ -53,7 +55,7 @@ def simulate(
     skycoords: SkyCoord,
     telescope_loc: EarthLocation,
     I_sky: np.ndarray,
-    beam_list: Sequence[UVBeam | Callable] | None,
+    beam_list: Sequence[UVBeam | AnalyticBeam | BeamInterface] | None,
     polarized: bool = False,
     antpairs: np.ndarray | list[tuple[int, int]] | None = None,
     beam_idx: np.ndarray | None = None,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,11 +5,14 @@ from astropy import units as un
 from astropy.coordinates import EarthLocation, Latitude, Longitude
 from astropy.time import Time
 from astropy.units import Quantity
+from dataclasses import replace
 from pathlib import Path
 from pyradiosky import SkyModel
 from pyuvdata import UVBeam
+from pyuvdata.analytic_beam import GaussianBeam
+from pyuvdata.beam_interface import BeamInterface
 from pyuvdata.telescopes import get_telescope
-from pyuvsim import AnalyticBeam, simsetup
+from pyuvsim import simsetup
 from pyuvsim.telescope import BeamList
 
 from matvis import DATA_PATH, coordinates
@@ -39,34 +42,36 @@ def get_standard_sim_params(
     # Beam model
     if use_analytic_beam:
         n_freq = nfreq
-        beam = AnalyticBeam("gaussian", diameter=14.0)
+        beam = BeamInterface(
+            GaussianBeam(diameter=14.0), beam_type="efield" if polarized else "power"
+        )
     else:
         n_freq = min(nfreq, 2)
         # This is a peak-normalized e-field beam file at 100 and 101 MHz,
         # downsampled to roughly 4 square-degree resolution.
         beam = UVBeam()
         beam.read_beamfits(beam_file)
-        if not polarized:
-            uvsim_beam = beam.copy()
-            beam.efield_to_power(calc_cross_pols=False, inplace=True)
-            beam.select(polarizations=["xx"], inplace=True)
+        # Even though we sometimes want a power beam for matvis, we always need
+        # an efield beam for pyuvsim, so we create an efield beam here, and let matvis
+        # take care of conversion later.
+        beam = BeamInterface(beam, beam_type="efield")
 
         # Now, the beam we have on file doesn't actually properly wrap around in azimuth.
         # This is fine -- the uvbeam.interp() handles the interpolation well. However, when
         # comparing to the GPU interpolation, which first has to interpolate to a regular
         # grid that ends right at 2pi, it's better to compare like for like, so we
         # interpolate to such a grid here.
-        beam = beam.interp(
-            az_array=np.linspace(0, 2 * np.pi, 181),
-            za_array=np.linspace(0, np.pi / 2, 46),
-            az_za_grid=True,
-            new_object=True,
+        beam = beam.clone(
+            beam=beam.beam.interp(
+                az_array=np.linspace(0, 2 * np.pi, 181),
+                za_array=np.linspace(0, np.pi / 2, 46),
+                az_za_grid=True,
+                new_object=True,
+            )
         )
 
-    if polarized or use_analytic_beam:
-        uvsim_beams = BeamList([beam])
-    else:
-        uvsim_beams = BeamList([uvsim_beam])
+    # The UVSim beams must be efield all the time.
+    uvsim_beams = BeamList([beam])
 
     beam_dict = {str(i): 0 for i in range(nants)}
 

--- a/tests/test_beams.py
+++ b/tests/test_beams.py
@@ -2,11 +2,13 @@
 
 import pytest
 
+import copy
 import numpy as np
 from pytest_lazy_fixtures import lf
 from pyuvdata import UVBeam
+from pyuvdata.analytic_beam import AnalyticBeam, GaussianBeam
+from pyuvdata.beam_interface import BeamInterface
 from pyuvdata.utils.pol import polnum2str, polstr2num
-from pyuvsim import AnalyticBeam
 
 from matvis import HAVE_GPU
 from matvis.core.beams import _wrangle_beams, prepare_beam_unpolarized
@@ -16,35 +18,32 @@ from matvis.cpu.beams import UVBeamInterpolator
 @pytest.fixture(scope="module")
 def efield_beam(uvbeam):
     """An e-field uvbeam."""
-    return uvbeam
+    return BeamInterface(uvbeam)
 
 
 @pytest.fixture(scope="function")
 def efield_single_freq(uvbeam):
     """Single frequency beam."""
-    return uvbeam.select(freq_chans=[0], inplace=False)
+    return BeamInterface(uvbeam.select(freq_chans=[0], inplace=False))
 
 
 @pytest.fixture(scope="module")
 def power_beam(uvbeam):
     """A power-beam."""
     beam = uvbeam.copy()
-    beam.efield_to_power()
-    return beam
+    return BeamInterface(beam, beam_type="power")
 
 
 @pytest.fixture(scope="function")
 def efield_analytic_beam() -> AnalyticBeam:
     """An efield analytic beam."""
-    return AnalyticBeam("gaussian", diameter=14.0)
+    return BeamInterface(GaussianBeam(diameter=14.0), beam_type="efield")
 
 
 @pytest.fixture(scope="function")
 def power_analytic_beam() -> AnalyticBeam:
     """A power analytic beam."""
-    beam = AnalyticBeam("gaussian", diameter=14.0)
-    beam.efield_to_power()
-    return beam
+    return BeamInterface(GaussianBeam(diameter=14.0), beam_type="efield")
 
 
 class TestWrangleBeams:
@@ -82,14 +81,6 @@ class TestWrangleBeams:
         ):
             _wrangle_beams(**(default_kw | {"beam_list": [power_beam]}))
 
-        with pytest.raises(ValueError, match="beam type must be power"):
-            _wrangle_beams(
-                **(
-                    default_kw
-                    | {"polarized": False, "beam_list": [efield_analytic_beam]}
-                )
-            )
-
 
 class TestPrepareBeamUnpolarized:
     """Test the prepare_beam_unpolarized function."""
@@ -109,20 +100,8 @@ class TestPrepareBeamUnpolarized:
 
         assert new_beam.beam_type == "power"
 
-        if isinstance(beam, UVBeam):
-            assert len(new_beam.polarization_array) == 1
-            assert polnum2str(new_beam.polarization_array[0]).lower() == "xx"
-
-    def test_exceptions(self, power_beam):
-        """Test that error is raised if desired polarization doesn't exist."""
-        beam = power_beam.copy()
-        beam.select(polarizations=[polstr2num("yy"), polstr2num("xy")])
-
-        with pytest.raises(
-            ValueError,
-            match="You want to use xx pol, but it does not exist in the UVBeam",
-        ):
-            prepare_beam_unpolarized(beam)
+        assert len(new_beam.beam.polarization_array) == 1
+        assert polnum2str(new_beam.beam.polarization_array[0]).lower() == "xx"
 
 
 class TestUVBeamInterpolator:
@@ -130,13 +109,13 @@ class TestUVBeamInterpolator:
 
     def test_nan_in_cpu_beam(self, efield_beam):
         """Test nan in cpu beam."""
-        beam = efield_beam.copy()
-        beam.data_array[1] = np.nan
+        beam = copy.deepcopy(efield_beam)
+        beam.beam.data_array[1] = np.nan
 
         tx = np.linspace(-1, 1, 100)
         ty = tx
 
-        freq = beam.freq_array[0]
+        freq = beam.beam.freq_array[0]
 
         bmfunc = UVBeamInterpolator(
             beam_list=[beam],

--- a/tests/test_matvis_cpu.py
+++ b/tests/test_matvis_cpu.py
@@ -4,8 +4,8 @@ import pytest
 
 import numpy as np
 from astropy.time import Time
+from pyuvdata.analytic_beam import GaussianBeam
 from pyuvdata.telescopes import get_telescope
-from pyuvsim.analyticbeam import AnalyticBeam
 
 from matvis import simulate_vis
 
@@ -38,7 +38,7 @@ def test_simulate_vis(polarized):
     times = Time(np.linspace(2459863.0, 2459864.0, NTIMES), format="jd")
 
     # Create beam models
-    beam = AnalyticBeam("gaussian", diameter=14.0)
+    beam = GaussianBeam(diameter=14.0)
 
     # Run matvis on CPUs with pixel beams
     vis = simulate_vis(

--- a/tests/test_matvis_gpu.py
+++ b/tests/test_matvis_gpu.py
@@ -5,7 +5,7 @@ import pytest
 pytest.importorskip("cupy")
 
 import numpy as np
-from pyuvsim.analyticbeam import AnalyticBeam
+from pyuvdata.analytic_beam import GaussianBeam
 
 from matvis import simulate_vis
 
@@ -48,7 +48,7 @@ def test_mixed_beams(uvbeam):
     """Test that error is raised when using a mixed beam list."""
     kw, *_ = get_standard_sim_params(use_analytic_beam=True, polarized=False)
 
-    anl = AnalyticBeam("gaussian", diameter=14.0)
+    anl = GaussianBeam(diameter=14.0)
     cpu_beams = [uvbeam, anl, anl]
     del kw["beams"]
 


### PR DESCRIPTION
<!--
Thank you for creating a PR on matvis!

Please read through the following and check the boxes to ensure
your PR meets our coding standards and that it follows the
correct pathways for testing and deployment.
-->

# Description
<!-- Write a brief description of what the new feature does, and how a review could take it for a spin -->

This updates several internal APIs to use the new `AnalyticBeam` and `BeamInterface` objects that came with pyuvdata 3.1.0. 

The user-facing API should be essentially unchanged, except that it is now allowed to pass `BeamInterface` objects in the `beams` parameter of `simulate()` and `simulate_vis()`.


# Checklist
I have

- [ ] Added a test covering your new feature adequately?
- [ ] Added a docstring (or note to a docstring) describing your feature?
- [ ] (Optional): Added a tutorial / section to a tutorial showing usage of your new feature?
- [ ] **Important**: this feature does *not* break API compatibility.
